### PR TITLE
Added the possibility to coinche an announce

### DIFF
--- a/anounce.py
+++ b/anounce.py
@@ -7,6 +7,7 @@ class Anounce():
         self.trump = COLOR_DICT[trump.capitalize()]
         self.capot = capot
         self.generale = generale
+        self.coinchee = False
 
     def __lt__(self, other):
         if other is None:
@@ -21,7 +22,15 @@ class Anounce():
             r = "Capot "
         elif self.generale:
             r = "Générale "
-        return r + str(self.trump)
+
+        c = ""
+        if self.coinchee:
+            c = " coinchée"
+
+        return r + str(self.trump) + c
+
+    def coinche(self):
+        self.coinchee = True
 
     def count_points(self, cards_won, players):
         cards = [cards_won[p] for p in players]

--- a/bot.py
+++ b/bot.py
@@ -110,6 +110,20 @@ async def bet(ctx, goal: str, trump: str):
     # Send the goal
     await table.bet(ctx, goal, trump, capot=capot, generale=generale)
 
+@bot.command()
+async def coinche(ctx):
+    global tables
+
+    # Find the table
+    try:
+        table = tables[ctx.channel.id]
+    except KeyError:
+        await delete_message(ctx.message)
+        await ctx.channel.send("Tu peux pas faire ça hors d'un channel de coinche...", delete_after=5)
+        return
+
+    # Try to coinche the last bet
+    await table.coinche(ctx)
 
 @bot.command(name="pass", aliases=["nik"])
 async def pass_annonce(ctx):

--- a/coinche.py
+++ b/coinche.py
@@ -125,6 +125,43 @@ class Coinche():
         await append_line(self.annonce_msg, " - " + self.players[self.active_player_index].mention + " : ?")
         await delete_message(ctx.message)
 
+    async def coinche(self, ctx):
+        # Check if we are in Bet Phase
+        if not self.bet_phase:
+            await delete_message(ctx.message)
+            await ctx.channel.send("La phase d'annonces est terminée " +
+                                   ctx.author.mention, delete_after=5)
+            return
+
+        # Check if there's something to coinche
+        if self.anounce is None:
+            await delete_message(ctx.message)
+            await ctx.channel.send("Il n'y a pas d'annonce à coincher pour le moment.", delete_after=5)
+            return
+
+        # Check if the player is in opposite team from the taker (i.e he can coinche)
+        if (self.taker_index)%2 == (self.players.index(ctx.author))%2:
+            await delete_message(ctx.message)
+            await ctx.channel.send("Ton équipe a proposé le dernier contrat. Tu ne peux pas coincher "
+                                    + ctx.author.mention, delete_after=5)
+            return
+
+        # Coinche the last anounce
+        self.anounce.coinche()
+
+        # Update message
+        await remove_last_line(self.annonce_msg)
+        await append_line(self.annonce_msg, " - " + ctx.author.mention + " : Coinchée")
+
+        self.bet_phase = False
+
+        await append_line(self.annonce_msg, "Fin des annonces")
+        await delete_message(ctx.message)
+
+        # Start the play phase
+        await self.setup_play()
+        return
+
     async def annonce(self, ctx, goal: int, trump, capot=False, generale=False):
         if self.bet_phase is False:
             await delete_message(ctx.message)


### PR DESCRIPTION
When in bet phase, typing `!coinche` will coinche the last announce made (if it was made by a member of the opposite team) and stop the beting phase